### PR TITLE
feat: add ability to get all security groups for a specific account

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ Params:
  
 Optional: 
 
+### ** Method getCloudSecurityGroupsIdsOfAccount
+
+Task: get all security group IDs for a specific account
+
+Params:
+
+ Mandatory: cloudAccountID(str)
+
+Optional:
 
 ## SDK Methods 
 

--- a/dome9ApiV2Py/dome9ApiV2Py.py
+++ b/dome9ApiV2Py/dome9ApiV2Py.py
@@ -277,6 +277,9 @@ class Dome9ApiClient(Dome9ApiSDK):
 	def getCloudSecurityGroupIDsOfVpc(self, vpcID):
     		return [secGrp['id'] for secGrp in self.getAwsSecurityGroups() if secGrp['vpcId'] == vpcID]
 
+        def getCloudSecurityGroupsIdsOfAccount(self, accountID):
+                return [secGrp['externalId'] for secGrp in self.getAwsSecurityGroups() if secGrp['awsAccountId'] == accountID]
+
 	def setCloudRegionsProtectedMode(self, ID, protectionMode, regions='all'):
 		if protectionMode not in Dome9ApiSDK.REGION_PROTECTION_MODES:
 			raise ValueError('Valid modes are: {}'.format(Dome9ApiSDK.REGION_PROTECTION_MODES))


### PR DESCRIPTION
It's handy to get the Security Group ID's for a specific account to enable/disable protection of Security Groups account wide.  The output of this method can be iteratively fed into setCloudSecurityGroupProtectionMode